### PR TITLE
Corrige le format du .rosinstall

### DIFF
--- a/src/.rosinstall
+++ b/src/.rosinstall
@@ -100,6 +100,6 @@
     uri: https://github.com/WalkingMachine/sara_moveit.git
     version: feature/simulation_safe
 - git:
- local-name: sara_msgs
- uri: https://github.com/walkingmachine/sara_msgs.git
- version: master
+    local-name: sara_msgs
+    uri: https://github.com/walkingmachine/sara_msgs.git
+    version: master


### PR DESCRIPTION
Il manquait une indentation à la fin du fichier.