### PR TITLE
Supprime aussi le build et le devel

### DIFF
--- a/script/clear_workspace.sh
+++ b/script/clear_workspace.sh
@@ -14,7 +14,7 @@ cd "$WSDIR"
 ######################################
 ## Update all packages
 
-rm -rf src/!(.rosinstall|.|..)
+rm -rf build devel src/!(.rosinstall|.|..)
 
 ######################################
 ## End


### PR DESCRIPTION
Fait que la fonction clear_workspace supprime aussi les build et le devel.
C'est pour que la commande clear puisse pratiquement "reset" le workspace complewtte