### PR TITLE
Feature/function delete extra packages

### DIFF
--- a/script/_delete_extra_packages.sh
+++ b/script/_delete_extra_packages.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+######################################
+## Preparation
+
+# Get the workspace path
+WSDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/.."
+
+# Move to the workspace
+cd "$WSDIR/src"
+
+
+######################################
+## Removal
+
+for F in */; do
+    if [ -z $( cat .rosinstall | gawk "/local-name:[ \t]*$F"' {print $2}') ]
+    then
+        echo "The repo \"$F\" is no longer needed. It will be deleted."
+        rm -rf $F
+    fi
+done
+
+
+######################################
+## End
+
+# Move back to the original position
+cd - > /dev/null

--- a/script/install.sh
+++ b/script/install.sh
@@ -38,6 +38,11 @@ source "$WSDIR/script/setup.sh"
 # Move to the workspace
 cd "$WSDIR"
 
+######################################
+## Remove extra repos
+
+bash -c "source script/_delete_extra_packages.sh"
+
 
 ######################################
 ## Installation


### PR DESCRIPTION
Fait que les repos superflus soient retiré quand on lance INSTALL_SARA.
Le script parcours le src et retire tout les dossiers qui ne sont pas mentionnés dans le .rosinstall.
Le script est automatiquement utilisé par le script install.
closes #59 